### PR TITLE
修复node版本在4以上的时候 被错误判断为IOJS的bug 改为使用环境变量IOJS来判定是否是IOJS

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -8,7 +8,7 @@ var fs = require('fs')
 var path = require('path')
 
 // var io = parseInt(process.version.slice(1), 10) >= 1 // yolo
-var io = process.env.IOJS && process.env.IOJS === 'TRUE'
+var io = process.env.IOJS === 'TRUE'
 var iojsDistUrl = process.env.NVM_IOJS_ORG_MIRROR || 'http://npm.taobao.org/mirrors/iojs/'
 if (iojsDistUrl[iojsDistUrl.length - 1] !== '/') {
   iojsDistUrl += '/'

--- a/bin.js
+++ b/bin.js
@@ -7,7 +7,8 @@ var zlib = require('zlib')
 var fs = require('fs')
 var path = require('path')
 
-var io = parseInt(process.version.slice(1), 10) >= 1 // yolo
+// var io = parseInt(process.version.slice(1), 10) >= 1 // yolo
+var io = process.env.IOJS && process.env.IOJS === 'TRUE'
 var iojsDistUrl = process.env.NVM_IOJS_ORG_MIRROR || 'http://npm.taobao.org/mirrors/iojs/'
 if (iojsDistUrl[iojsDistUrl.length - 1] !== '/') {
   iojsDistUrl += '/'


### PR DESCRIPTION
node版本在4以上,默认判定为IOJS,修复此问题,改为使用IOJS环境变量在nodejs和iojs间切换

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnpm/node-gyp-install/2)
<!-- Reviewable:end -->
